### PR TITLE
Add simple GPT-powered business plan web app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, render_template, request, jsonify
+import openai
+import os
+
+app = Flask(__name__)
+openai.api_key = os.getenv('OPENAI_API_KEY', 'YOUR_OPENAI_API_KEY')
+
+GPT_INSTRUCTIONS = """
+你是一位商业计划书和营运计划书专家，请按以下步骤完成内容：
+1. 简要概述主题与市场需求
+2. 分析目标客户及市场规模
+3. 制定产品和营销策略，描述商业模式
+4. 提出运营计划、团队架构和财务预测
+"""
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/generate', methods=['POST'])
+def generate_plan():
+    data = request.get_json()
+    topic = data.get('topic')
+    if not topic:
+        return jsonify({'error': 'No topic provided'}), 400
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": GPT_INSTRUCTIONS},
+            {"role": "user", "content": f"请为以下主题生成计划：{topic}"}
+        ]
+    )
+    plan_text = response['choices'][0]['message']['content']
+    return jsonify({'plan': plan_text})
+
+if __name__ == '__main__':
+    app.run(port=5000, debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>GPT 商业计划生成</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    #output { white-space: pre-wrap; margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h2>商业计划书生成器</h2>
+  <label for="topic">输入主题（例如：智能冰箱）：</label><br>
+  <textarea id="topic" rows="4" cols="50"></textarea><br><br>
+  <button id="submitBtn">生成计划</button>
+
+  <div id="output"></div>
+
+<script>
+document.getElementById('submitBtn').addEventListener('click', async () => {
+  const topic = document.getElementById('topic').value.trim();
+  if (!topic) { return; }
+
+  const response = await fetch('/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ topic: topic })
+  });
+
+  if (response.ok) {
+    const data = await response.json();
+    document.getElementById('output').textContent = data.plan;
+  } else {
+    document.getElementById('output').textContent = '生成失败';
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based web app to generate business plans with GPT
- include HTML frontend for user interaction

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6868cf1a0c788328bb78213e59b34329